### PR TITLE
Reworked multiple upload files mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Posts the content of the pages.
 **Usage**:
 
 ```console
-$ confluence_poster post-page [OPTIONS]
+$ confluence_poster post-page [OPTIONS] [FILES]...
 ```
 
 **Options**:
 
-* `--upload-files PATH`: Files to upload as attachments to page.
+* `--upload-files`: Upload list of files
 * `--help`: Show this message and exit.
 
 ## `confluence_poster validate`

--- a/confluence_poster/main.py
+++ b/confluence_poster/main.py
@@ -153,9 +153,10 @@ state = StateConfig()
 
 @app.command()
 def post_page(
-    upload_files: Optional[List[Path]] = typer.Option(
-        default=None, help="Files to upload as attachments to page."
-    )
+    upload_files: Optional[bool] = typer.Option(
+        False, "--upload-files", show_default=False, help="Upload list of files"
+    ),
+    files: Optional[List[Path]] = typer.Argument(None, help="List of files to upload"),
 ):
     """Posts the content of the pages."""
     report = Report(confluence_instance=state.confluence_instance)
@@ -224,7 +225,7 @@ def post_page(
         if page_id and upload_files:
             typer.echo("Uploading the files")
             if page == target_page:
-                for path in upload_files:
+                for path in files:
                     if path.is_file():
                         typer.echo(f"\tUploading file {path.name}")
                         state.confluence_instance.attach_file(

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -52,12 +52,18 @@ def gen_attachments(tmp_path):
     return result
 
 
-def test_upload_files_single_page_config(setup_page, gen_attachments):
+@pytest.mark.parametrize(
+    "file_count",
+    range(1, 10),
+    ids=lambda file_count: f"Upload {file_count} files to existing page",
+)
+def test_upload_files_single_page_config(setup_page, gen_attachments, file_count):
     """Tests uploading files to a page - should work"""
     page_id, config_file = setup_page
-    file_to_upload, filename = gen_attachments[0]
+    files_to_upload = [_[0] for _ in gen_attachments[:file_count]]
+    _, filename = gen_attachments[0]
 
-    result: Result = upload_files(config_file=config_file, other_args=[file_to_upload])
+    result: Result = upload_files(config_file=config_file, other_args=files_to_upload)
     assert result.exit_code == 0
     assert "Uploading the files" in result.stdout
     assert f"\tUploading file {filename}" in result.stdout


### PR DESCRIPTION
Now --upload-files works as a boolean switch that makes the post-page
command to look for supplied list of files in the command line and
upload them

Closes #26