### PR TITLE
Added extra line for dialog prompt

### DIFF
--- a/confluence_poster/config_wizard.py
+++ b/confluence_poster/config_wizard.py
@@ -77,7 +77,7 @@ def _dialog_prompt(parameter: Union[DialogParameter, str], default_value=None) -
         message += [f"Current value is {default_value}. Press [Enter] to use it."]
 
     new_value = typer.prompt(
-        text="\n".join(message),
+        text="\n".join(message) + "\nValue",
         default=_default_value,
         type=parameter.type,
         hide_input=parameter.hide_input,

--- a/tests/unit tests/test_config_wizard_helpers.py
+++ b/tests/unit tests/test_config_wizard_helpers.py
@@ -220,6 +220,20 @@ def test_single_dialog_prompt(
             assert output not in captured.out
 
 
+def test_single_dialog_prompt_extra_line(monkeypatch, capsys):
+    """Checks that dialogs are output in the format
+    Title
+    Comment: foo
+    Value: <user input>
+    """
+    monkeypatch.setattr("sys.stdin", io.StringIO("value" + "\n"))
+    _dialog_prompt(
+        parameter=DialogParameter("Title", comment="Comment"),
+    )
+    captured = capsys.readouterr()
+    assert captured.out.count("\n") == 2
+
+
 def test_dialog_parameter_methods():
     inner_string = "title"
     d1 = DialogParameter(inner_string)


### PR DESCRIPTION
Now the dialog prompt looks like:

    Title
    Comment: foo
    Value: <user input>

Closes #44.